### PR TITLE
Fixed typo in example_script.

### DIFF
--- a/example_script.sh
+++ b/example_script.sh
@@ -11,4 +11,4 @@ echo -e "\033[33mCongratulations!\033[0m You've successfully run your first buil
 
 If you need any more help, please email us at hello@buildbox.io
 
-\033[31m<3\033[0m Buildobx"
+\033[31m<3\033[0m Buildbox"


### PR DESCRIPTION
Buildbox was misspelled, fixed it here. Really small change.
