### PR TITLE
Pass $BUILDKITE_AGENT_META_DATA_QUEUE to pipeline.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,3 +2,5 @@ steps:
   - name: ":hammer: Example Script"
     command: "script.sh"
     artifact_paths: "artifacts/*"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"

--- a/script.sh
+++ b/script.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -eo pipefail
 
 echo "--- :package: Build job checkout directory"


### PR DESCRIPTION
Reimplement keeping the queue value for subsequent steps.

NOTE: This requires Agent 3.0 to be stable.