### PR TITLE
Update pipeline.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,5 +2,3 @@ steps:
   - label: ":hammer: Example Script"
     command: "script.sh"
     artifact_paths: "artifacts/*"
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"


### PR DESCRIPTION
Remove agent queue target from pipeline configuration. Starter pipeline can just use any queue to begin with.

It's unlikely that anyone will run into the same issue I did, but it's probably unnecessary complexity for "Step 1", in getting a pipeline up and running.